### PR TITLE
Fix icon display and pane navigation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 **Current Version:** 0.6.0 (The "Manager" Update)
 
+### **Recent Updates** (2025-11-22)
+* ✅ **Icon Display Improvements:** Enhanced icon rendering with consistent sizing (14pt) across all panes
+* ✅ **Navigation Fix:** Corrected pane navigation behavior - clicking the active directory in parent pane now navigates up
+* ✅ **UX Enhancement:** Improved Miller column navigation to match expected file manager behavior
+
 ## **Core Features**
 
 ### **Interface & Layout**
@@ -77,9 +82,10 @@
 ## **Planned Enhancements**
 
 ### **Icon System Improvements**
+* [x] Consistent icon sizing across all panes (14pt)
 * [ ] Nerd Font support for professional icon rendering
 * [ ] Custom icon themes
-* [ ] Icon size configuration
+* [ ] Icon size configuration option
 
 ### **Enhanced Syntax Highlighting**
 * [ ] Full syntax highlighting library integration (syntect or tree-sitter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -717,7 +717,9 @@ impl Heike {
                             .body(|body| {
                                 body.rows(24.0, entries.len(), |mut row| {
                                     let preview_entry = &entries[row.index()];
-                                    row.col(|ui| { ui.label(preview_entry.get_icon()); });
+                                    row.col(|ui| {
+                                        ui.label(egui::RichText::new(preview_entry.get_icon()).size(14.0));
+                                    });
                                     row.col(|ui| {
                                         if ui.selectable_label(false, &preview_entry.name).clicked() {
                                             *next_navigation.borrow_mut() = Some(preview_entry.path.clone());
@@ -905,11 +907,22 @@ impl eframe::App for Heike {
 
                             if is_active { row.set_selected(true); }
 
-                            row.col(|ui| { ui.label(entry.get_icon()); });
+                            row.col(|ui| {
+                                ui.label(egui::RichText::new(entry.get_icon()).size(14.0));
+                            });
                             row.col(|ui| {
                                 let text_color = if is_active { egui::Color32::from_rgb(100, 200, 255) } else { ui.visuals().text_color() };
                                 if ui.selectable_label(is_active, egui::RichText::new(&entry.name).color(text_color)).clicked() {
-                                    *next_navigation.borrow_mut() = Some(entry.path.clone());
+                                    // If clicking the active directory in parent pane, navigate UP to parent
+                                    // Otherwise, navigate to the clicked sibling directory
+                                    if is_active {
+                                        // Navigate to the parent of current (go up one level)
+                                        if let Some(parent_path) = self.current_path.parent() {
+                                            *next_navigation.borrow_mut() = Some(parent_path.to_path_buf());
+                                        }
+                                    } else {
+                                        *next_navigation.borrow_mut() = Some(entry.path.clone());
+                                    }
                                 }
                             });
                         });
@@ -1012,7 +1025,9 @@ impl eframe::App for Heike {
                             if is_multi_selected || is_focused { row.set_selected(true); }
 
                             // Icon column
-                            row.col(|ui| { ui.label(entry.get_icon()); });
+                            row.col(|ui| {
+                                ui.label(egui::RichText::new(entry.get_icon()).size(14.0));
+                            });
 
                             // Name column with context menu
                             row.col(|ui| {


### PR DESCRIPTION
This commit addresses two key UX improvements:

1. Icon Display: Enhanced icon rendering with consistent 14pt sizing across all three panes (parent, current, preview) for better visual consistency and readability.

2. Pane Navigation: Fixed Miller column navigation behavior where clicking the active/highlighted directory in the parent pane now correctly navigates UP to the parent directory, matching expected file manager behavior. Previously, clicking the active item would navigate to itself (no-op).

These changes improve the overall user experience and make the navigation more intuitive and aligned with standard Miller column file managers.