### PR TITLE
Add ripgrep-all style content search functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +611,17 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1301,6 +1321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1784,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1926,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,12 +2002,17 @@ dependencies = [
  "eframe",
  "egui_extras",
  "flate2",
+ "grep-matcher",
+ "grep-regex",
+ "grep-searcher",
  "id3",
+ "ignore",
  "image",
  "lopdf",
  "notify",
  "open",
  "pulldown-cmark",
+ "rayon",
  "resvg",
  "syntect",
  "tar",
@@ -2099,6 +2183,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3715,6 +3815,17 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heike"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]
@@ -22,3 +22,8 @@ tar = "0.4"      # For TAR archive preview
 flate2 = "1.0"   # For gzip decompression
 id3 = "1.14"     # For audio metadata
 lopdf = "0.34"   # For PDF metadata reading
+grep-searcher = "0.1" # For efficient text searching
+grep-regex = "0.1"   # For regex matching in search
+grep-matcher = "0.1" # For grep matching interface
+ignore = "0.4"   # For gitignore-aware file walking
+rayon = "1.10"   # For parallel search operations

--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@
 
 ## **Project Status: Active Prototype**
 
-**Current Version:** 0.6.0 (The "Manager" Update)
+**Current Version:** 0.7.0 (The "Search" Update)
 
-### **Recent Updates** (2025-11-22)
+### **Recent Updates** (2025-11-23)
+
+#### **Content Search Integration**
+* ✅ **Ripgrep-all Style Search:** Added full content search with Shift+S keybinding
+* ✅ **Multi-Format Support:** Search in text files, PDFs, and ZIP archives
+* ✅ **Advanced Options:** Case sensitivity, regex support, hidden files, configurable limits
+* ✅ **Smart File Walking:** Gitignore-aware with the `ignore` crate
+* ✅ **Results Navigation:** Navigate matches with n/N, preview in dedicated pane
+* ✅ **Efficient Search:** Powered by grep-searcher for high performance
+
+### **Previous Updates** (2025-11-22)
 
 #### **Layout & Interaction Improvements**
 * ✅ **Fixed Column Widths:** Set reasonable defaults and disabled auto-resize based on content for more stable layout
@@ -73,6 +83,12 @@
 * **Feedback System:** Info and error message toasts in bottom bar
 
 ### **Search & Filtering**
+* **Content Search (NEW):** Press `Shift+S` to search file contents recursively
+  * Full ripgrep-like functionality with regex support
+  * Search in PDFs, ZIP archives, and text files
+  * Gitignore-aware file walking
+  * Navigate results with `n`/`N` (next/previous match)
+  * Press `Enter` to open file at match location
 * **Fuzzy Filter:** Press `/` to filter current view instantly
 * **Enter to Finalize:** Search finalizes on Enter, allowing navigation in filtered results
 * **Hidden Files Toggle:** `.` key or checkbox to show/hide hidden files
@@ -161,7 +177,7 @@
 * [ ] Multiple workspace tabs
 * [ ] Split panes for side-by-side file management
 * [ ] Bulk rename operations
-* [ ] File search across directories
+* [x] File search across directories (content search with Shift+S)
 * [ ] Plugin system (Lua or Wasm)
 * [ ] Embedded terminal pane
 * [ ] Git integration indicators


### PR DESCRIPTION
Implement comprehensive content search feature following Option 2 (pure Rust integration) with Yazi-style keybindings:

**Core Features:**
- Full-text search across files with Shift+S keybinding (matching Yazi convention)
- Support for text files, PDFs (via lopdf), and ZIP archives
- Powered by grep-searcher, grep-regex, grep-matcher for high performance
- Gitignore-aware file walking using ignore crate

**Search Capabilities:**
- Case-sensitive and regex search options
- Configurable hidden file search
- Max results limit (default 1000)
- Progress tracking during search
- Async non-blocking search with worker thread

**UI/UX:**
- Search input modal with checkboxes for options (case, regex, hidden, PDFs, archives)
- Two-column results view: matches list + preview pane
- Results show file:line format with content preview
- Navigation with n/N for next/previous match, j/k for up/down
- Enter to open file, Escape to return to normal mode
- Search mode indicator in status bar

**Implementation:**
- New data structures: SearchResult, SearchOptions
- New AppMode variants: SearchInput, SearchResults
- New IoCommand/IoResult for async search
- Integrated with existing async architecture and worker thread
- Added search keybinding to help modal

**Dependencies Added:**
- grep-searcher 0.1
- grep-regex 0.1
- grep-matcher 0.1
- ignore 0.4
- rayon 1.10

Version bumped to 0.7.0 (The "Search" Update)